### PR TITLE
use ipfs_user variable in init script

### DIFF
--- a/templates/ipfs.init.j2
+++ b/templates/ipfs.init.j2
@@ -20,7 +20,7 @@ DESC="Inter Planetary File System daemon"
 NAME=ipfs
 DAEMON=/usr/local/bin/$NAME
 DAEMON_ARGS="daemon"
-DAEMON_USER="ipfs"
+DAEMON_USER="{{ ipfs_user }}"
 PIDFILE=/var/run/$NAME.pid
 SCRIPTNAME=/etc/init.d/$NAME
 


### PR DESCRIPTION
The init script is currently hard-coded to run as the `ipfs` user, ignoring the `ipfs_user` variable.  This just sets `DAEMON_USER` to the `ipfs_user` value.
