### PR TITLE
workaround ipfs init failure if stdin is not a tty

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,7 +24,7 @@
 - include: install-ipfs.yml
 
 - name: initialize ipfs
-  command: creates="/home/{{ ipfs_user }}/.ipfs/version" su -c "/usr/local/bin/ipfs init" "{{ ipfs_user }}"
+  command: creates="/home/{{ ipfs_user }}/.ipfs/version" su -c "script --return -c '/usr/local/bin/ipfs init' /dev/null" "{{ ipfs_user }}"
   register: init
 
 - debug: var=init


### PR DESCRIPTION
ipfs 0.4.2 (and possibly prior versions) fails to run `ipfs init` when stdin is not a tty: https://github.com/ipfs/go-ipfs/issues/2748

This commit uses [this trick](http://stackoverflow.com/questions/1401002/trick-an-application-into-thinking-its-stdin-is-interactive-not-a-pipe) to fake an interactive tty, which causes the command to succeed.

The bug has been fixed in go-ipfs master, but there's no release available yet.  I don't know if you want to have this workaround in place to support the affected versions, or just wait it out :)
